### PR TITLE
Support terragrunt 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v0.9.0
+### Changed
+* switched to $GITHUB_OUTPUT: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
 
 ## v0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## v1.0.0
+### Changed
+* terragrunt 1.x support: default `TG_TF_PATH` to `terraform` (terragrunt 1.x otherwise looks for OpenTofu), overridable from the workflow.
+* `plan` and `apply` now run with `-no-color` so build logs and PR comments stay readable.
+
 ## v0.9.0
 ### Changed
 * switched to $GITHUB_OUTPUT: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

--- a/src/main.sh
+++ b/src/main.sh
@@ -163,6 +163,8 @@ function main {
   parseInputs
   configureCLICredentials
   installTerraform
+  # terragrunt 1.x defaults to OpenTofu; this image ships terraform only
+  export TG_TF_PATH="${TG_TF_PATH:-terraform}"
   cd ${GITHUB_WORKSPACE}/${tfWorkingDir}
 
   case "${tfSubcommand}" in

--- a/src/terragrunt_apply.sh
+++ b/src/terragrunt_apply.sh
@@ -3,7 +3,7 @@
 function terragruntApply {
   # Gather the output of `terragrunt apply`.
   echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
-  applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)
+  applyOutput=$(${tfBinary} apply -auto-approve -input=false -no-color ${*} 2>&1)
   applyExitCode=${?}
   applyCommentStatus="Failed"
 

--- a/src/terragrunt_fmt.sh
+++ b/src/terragrunt_fmt.sh
@@ -67,12 +67,12 @@ ${fmtComment}
   fi
 
   # Write changes to branch
-  echo "::set-output name=tf_actions_fmt_written::false"
+  echo "name=tf_actions_fmt_written::false" >> $GITHUB_OUTPUT
   if [ "${tfFmtWrite}" == "1" ]; then
     echo "fmt: info: Terraform files in ${tfWorkingDir} will be formatted"
     terraform fmt -write=true ${fmtRecursive} "${*}"
     fmtExitCode=${?}
-    echo "::set-output name=tf_actions_fmt_written::true"
+    echo "name=tf_actions_fmt_written::true"  >> $GITHUB_OUTPUT
   fi
 
   exit ${fmtExitCode}

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -17,7 +17,7 @@ function terragruntOutput {
     outputOutput="${outputOutput//$'\n'/'%0A'}"
     outputOutput="${outputOutput//$'\r'/'%0D'}"
 
-    echo "::set-output name=tf_actions_output::${outputOutput}"
+    echo "name=tf_actions_output::${outputOutput}"  >> $GITHUB_OUTPUT
     exit ${outputExitCode}
   fi
 

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -13,7 +13,7 @@ function terragruntPlan {
     echo "plan: info: successfully planned Terragrunt configuration in ${tfWorkingDir}"
     echo "${planOutput}"
     echo
-    echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+    echo name=tf_actions_plan_has_changes::${planHasChanges} >> $GITHUB_OUTPUT
     exit ${planExitCode}
   fi
 
@@ -63,13 +63,13 @@ ${planOutput}
     echo "${planPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${planCommentsURL}" > /dev/null
   fi
 
-  echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+  echo name=tf_actions_plan_has_changes::${planHasChanges}  >> $GITHUB_OUTPUT
 
   # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
   planOutput="${planOutput//'%'/'%25'}"
   planOutput="${planOutput//$'\n'/'%0A'}"
   planOutput="${planOutput//$'\r'/'%0D'}"
 
-  echo "::set-output name=tf_actions_plan_output::${planOutput}"
+  echo "name=tf_actions_plan_output::${planOutput}"  >> $GITHUB_OUTPUT
   exit ${planExitCode}
 }

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -3,7 +3,7 @@
 function terragruntPlan {
   # Gather the output of `terragrunt plan`.
   echo "plan: info: planning Terragrunt configuration in ${tfWorkingDir}"
-  planOutput=$(${tfBinary} plan -detailed-exitcode -input=false ${*} 2>&1)
+  planOutput=$(${tfBinary} plan -detailed-exitcode -input=false -no-color ${*} 2>&1)
   planExitCode=${?}
   planHasChanges=false
   planCommentStatus="Failed"


### PR DESCRIPTION
Terragrunt 1.x resolves the OpenTofu binary by default; this image installs terraform only, so `TG_TF_PATH` now defaults to `terraform` (still overridable from the calling workflow).

`plan` and `apply` also run with `-no-color` so raw logs and PR comments are readable.

Consumed by fn_ml_py_models EKS model deployment workflow, which moves to terraform 1.15.8 / terragrunt v1.1.1.